### PR TITLE
Fix spinner displaying incorrect download progress

### DIFF
--- a/src/types/node/release.rs
+++ b/src/types/node/release.rs
@@ -73,7 +73,7 @@ impl Release {
                               content_length as f64 / BYTES_PER_MB
                           )),
                       ))?;
-                      
+
                       last_update = Instant::now();
                     }
                 }


### PR DESCRIPTION
Added a short debounce timer before updating the spinner's title is updated.

This prevents the incorrect download progress display  (previously showed incorrect final sizes like `0.3/21MiB` due to rapid updates).

